### PR TITLE
Add environment template and document setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-# Configuration du système de prédictions football
-RAPIDAPI_KEY=e1e76b8e3emsh2445ffb97db0128p158afdjsnb3175ce8d916
-
-# Instructions d'utilisation:
-# Source ce fichier avant de lancer les scripts:
-# source .env
-# puis: python3 daily_predictions_workflow.py

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+RAPIDAPI_KEY=<votre-clé>

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__/
 # Data artifacts
 *.parquet
 analysis/predictions/
+
+# Environment variable files
+.env
+.env.*
+!.env.template

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Voici une description des fichiers et dossiers importants du projet :
 └── requirements.txt        # Liste des dépendances Python nécessaires
 ```
 
+## 🔐 Configuration de l'API
+
+Avant de lancer les scripts, copiez le fichier `.env.template` en `.env` et renseignez votre clé RapidAPI :
+
+```bash
+cp .env.template .env
+# Puis éditez .env et remplacez <votre-clé> par votre clé RapidAPI
+source .env
+```
+
 ## 🚀 Comment Utiliser
 
 - **Pour tester le système :** Le moyen le plus simple de vérifier que tout fonctionne est de lancer le script de test complet.

--- a/README_PREDICTIONS.md
+++ b/README_PREDICTIONS.md
@@ -50,8 +50,12 @@ pip install -r requirements.txt
 
 ### 2. Configuration de la clé API
 
+Copiez le modèle `.env.template` en `.env` puis ajoutez votre clé :
+
 ```bash
-export RAPIDAPI_KEY='your_rapidapi_key_here'
+cp .env.template .env
+# Éditez .env et remplacez <votre-clé> par votre clé RapidAPI
+source .env
 ```
 
 ### 3. Setup automatique
@@ -196,8 +200,9 @@ sudo systemctl status football-predictions
 
 ### Erreur "Clé API manquante"
 ```bash
-export RAPIDAPI_KEY='your_key_here'
-# Ou ajoutez-la à votre .bashrc/.zshrc
+cp .env.template .env  # si le fichier n'existe pas
+# Ajoutez votre clé dans .env puis chargez-le
+source .env
 ```
 
 ### Erreur "Données historiques manquantes"


### PR DESCRIPTION
## Summary
- remove `.env` from version control and ignore environment files
- add `.env.template` for RAPIDAPI_KEY and update documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aef4d68cb88333bc9d37acb03c611a