### PR TITLE
Parameterize demo CSV paths

### DIFF
--- a/src/create_custom_csvs.py
+++ b/src/create_custom_csvs.py
@@ -1,39 +1,57 @@
 import pandas as pd
 import os
 
-def create_daily_elo_csv():
-    """
-    Reads the daily Elo predictions, filters out cup matches,
-    and saves the result to a new CSV file.
+
+def create_daily_elo_csv(
+    input_path: str = "data/predictions/daily_elo_predictions.csv",
+    output_path: str = "todays_leagues_elo.csv",
+):
+    """Create a CSV with only league matches from daily Elo predictions.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the CSV containing the daily Elo predictions.
+    output_path:
+        Destination path for the filtered league matches.
     """
     try:
-        daily_predictions_df = pd.read_csv('data/predictions/daily_elo_predictions_2025-08-23.csv')
+        daily_predictions_df = pd.read_csv(input_path)
 
-        # Filter out cup matches, keeping only league matches
+        # Filter out cup matches, keeping only league matches.
         # We assume anything with "Cup" in the name is a cup match.
-        league_matches_df = daily_predictions_df[~daily_predictions_df['league_name'].str.contains("Cup", case=False, na=False)]
+        league_matches_df = daily_predictions_df[
+            ~daily_predictions_df["league_name"].str.contains("Cup", case=False, na=False)
+        ]
 
-        output_path = 'todays_leagues_elo.csv'
         league_matches_df.to_csv(output_path, index=False)
         print(f"Successfully created {output_path}")
 
     except FileNotFoundError:
-        print("Error: data/predictions/daily_elo_predictions_2025-08-23.csv not found.")
+        print(f"Error: {input_path} not found.")
     except Exception as e:
         print(f"An error occurred: {e}")
 
-def create_historical_matches_csv():
+def create_historical_matches_csv(
+    matches_dir: str = "data/matches", output_path: str = "historical_matches.csv"
+):
+    """Combine all historical match data into a single CSV file.
+
+    Parameters
+    ----------
+    matches_dir:
+        Directory containing match CSV files.
+    output_path:
+        Destination path for the combined CSV.
     """
-    Combines all historical match data from the data/matches
-    directory into a single CSV file.
-    """
-    matches_dir = 'data/matches'
     try:
         if not os.path.isdir(matches_dir):
             print(f"Error: Directory '{matches_dir}' not found.")
             return
 
-        all_matches_files = [os.path.join(matches_dir, f) for f in os.listdir(matches_dir) if f.endswith('.csv')]
+        all_matches_files = [
+            os.path.join(matches_dir, f) for f in os.listdir(matches_dir) if f.endswith(".csv")
+        ]
 
         if not all_matches_files:
             print(f"No CSV files found in '{matches_dir}'.")
@@ -42,7 +60,6 @@ def create_historical_matches_csv():
         df_list = [pd.read_csv(file) for file in all_matches_files]
         combined_df = pd.concat(df_list, ignore_index=True)
 
-        output_path = 'historical_matches.csv'
         combined_df.to_csv(output_path, index=False)
         print(f"Successfully created {output_path}")
 

--- a/src/test_complete_system.py
+++ b/src/test_complete_system.py
@@ -143,7 +143,7 @@ def test_csv_format():
     try:
         import pandas as pd
         
-        demo_file = 'data/predictions/demo_daily_2025-08-22.csv'
+        demo_file = 'data/predictions/demo_daily.csv'
         if os.path.exists(demo_file):
             df = pd.read_csv(demo_file)
             
@@ -246,7 +246,7 @@ def generate_sample_report():
     try:
         import pandas as pd
         
-        demo_file = 'data/predictions/demo_daily_2025-08-22.csv'
+        demo_file = 'data/predictions/demo_daily.csv'
         if os.path.exists(demo_file):
             df = pd.read_csv(demo_file)
             


### PR DESCRIPTION
## Summary
- allow overriding prediction input/output paths in `create_custom_csvs.create_daily_elo_csv`
- make `create_historical_matches_csv` configurable
- update demo tests to reference a generic `demo_daily.csv`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aefb8515b48333955f3e19b5407127