### PR TITLE
docs: update prediction file references

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ Voici une description des fichiers et dossiers importants du projet :
 │   ├── odds/
 │   │   └── raw_data/       # Contient les données brutes des cotes pour tous les types de paris
 │   └── predictions/        # Contient les fichiers de prédictions générés
-│       ├── daily_elo_predictions_YYYY-MM-DD.csv   # Prédictions quotidiennes
-│       └── historical_elo_predictions_with_results.csv # Fichier enrichi avec les résultats
+│       ├── daily_predictions.csv          # Prédictions quotidiennes par similarité
+│       ├── daily_elo_predictions.csv      # Prédictions quotidiennes basées sur l'ELO
+│       ├── historical_predictions.csv     # Historique cumulatif des prédictions
+│       └── historical_elo_predictions.csv # Historique cumulatif des prédictions ELO
 ├── src/                    # Contient tout le code source du projet
 │   ├── analysis/           # Scripts pour l'analyse des données et des prédictions
 │   │   └── predictions_analyzer.py # Contient la logique pour enrichir les données

--- a/README_PREDICTIONS.md
+++ b/README_PREDICTIONS.md
@@ -6,10 +6,10 @@ Ce système génère automatiquement des prédictions quotidiennes pour les matc
 
 ## 🎯 Fonctionnalités
 
-- **Prédictions quotidiennes** : Génère un CSV quotidien avec tous les matchs du jour
+- **Prédictions quotidiennes** : Génère un fichier `daily_predictions.csv` (et `daily_elo_predictions.csv` pour l'ELO) avec tous les matchs du jour
 - **Analyse complète** : Calcule les % de similarité pour TOUS les types de paris
 - **Base de données robuste** : Utilise les données combinées de 15 ligues
-- **Historique complet** : Maintient un CSV historique pour analyses avancées
+- **Historique complet** : Accumule les données dans `historical_predictions.csv` et `historical_elo_predictions.csv`
 - **Scheduling automatique** : Exécution automatisée à heures définies
 - **Analyses avancées** : Outils d'analyse et de visualisation des résultats
 
@@ -30,8 +30,10 @@ Ce système génère automatiquement des prédictions quotidiennes pour les matc
 │       └── ...
 ├── data/
 │   ├── predictions/
-│   │   ├── daily_YYYY-MM-DD.csv
-│   │   └── historical_predictions.csv
+│   │   ├── daily_predictions.csv
+│   │   ├── daily_elo_predictions.csv
+│   │   ├── historical_predictions.csv
+│   │   └── historical_elo_predictions.csv
 │   ├── elo_ratings.csv
 │   └── ...
 ├── .github/workflows/
@@ -285,7 +287,7 @@ python3 src/analysis/elo_calculator.py
 Un workflow quotidien génère des prédictions basées uniquement sur le classement Elo des équipes.
 
 **Fichiers Générés:**
-- `data/predictions/daily_elo_predictions_YYYY-MM-DD.csv`: Contient les prédictions Elo pour les matchs du jour.
+- `data/predictions/daily_elo_predictions.csv`: Contient les prédictions Elo pour les matchs du jour.
 - `data/predictions/historical_elo_predictions.csv`: Archive toutes les prédictions Elo générées.
 
 **Format du CSV:**


### PR DESCRIPTION
## Summary
- document new daily prediction filenames
- detail accumulation into historical prediction archives

## Testing
- `pytest`
- `pre-commit run --files README.md README_PREDICTIONS.md` *(fails: pre-commit missing and installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68aefb8588648333b30abdc192148c96