### PR TITLE
Use fixed prediction file names

### DIFF
--- a/src/site_generator/generator.py
+++ b/src/site_generator/generator.py
@@ -47,8 +47,8 @@ def generate_site():
     today_str = datetime.utcnow().strftime('%Y-%m-%d')
 
     # Prédictions du jour
-    elo_preds_path = f'data/predictions/daily_elo_predictions_{today_str}.csv'
-    odds_preds_path = f'data/predictions/daily_{today_str}.csv'
+    elo_preds_path = 'data/predictions/daily_elo_predictions.csv'
+    odds_preds_path = 'data/predictions/daily_predictions.csv'
     elo_predictions_data = load_csv_to_dict(elo_preds_path, "Prédictions Elo du jour")
     odds_predictions_data = load_csv_to_dict(odds_preds_path, "Prédictions Cotes du jour")
 


### PR DESCRIPTION
## Summary
- Read daily Elo and odds predictions from fixed file names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aefb89282483338e4a44bd80b85559