### PR TITLE
feat: streamline daily predictions output

### DIFF
--- a/README_PREDICTIONS.md
+++ b/README_PREDICTIONS.md
@@ -30,7 +30,7 @@ Ce système génère automatiquement des prédictions quotidiennes pour les matc
 │       └── ...
 ├── data/
 │   ├── predictions/
-│   │   ├── daily_YYYY-MM-DD.csv
+│   │   ├── daily_predictions.csv
 │   │   └── historical_predictions.csv
 │   ├── elo_ratings.csv
 │   └── ...

--- a/src/analysis/predictions_analyzer.py
+++ b/src/analysis/predictions_analyzer.py
@@ -156,11 +156,11 @@ class PredictionsAnalyzer:
         return pd.DataFrame(high_confidence_matches)
     
     def generate_daily_report(self, target_date: str = None) -> str:
-        """Génère un rapport pour une date donnée"""
+        """Génère un rapport basé sur le fichier quotidien actuel"""
         if target_date is None:
             target_date = date.today().strftime('%Y-%m-%d')
-        
-        daily_file = os.path.join(self.predictions_dir, f"daily_{target_date}.csv")
+
+        daily_file = os.path.join(self.predictions_dir, "daily_predictions.csv")
         
         if not os.path.exists(daily_file):
             logger.error(f"Fichier quotidien non trouvé: {daily_file}")

--- a/src/prediction/daily_predictions_workflow.py
+++ b/src/prediction/daily_predictions_workflow.py
@@ -289,9 +289,16 @@ class DailyPredictionsWorkflow:
         """
         Crée les fichiers CSV quotidien et historique
         """
-        daily_filename = f"daily_{self.today.strftime('%Y-%m-%d')}.csv"
-        daily_filepath = os.path.join(self.predictions_dir, daily_filename)
+        daily_filepath = os.path.join(self.predictions_dir, "daily_predictions.csv")
         historical_filepath = os.path.join(self.predictions_dir, "historical_predictions.csv")
+
+        # Supprimer les anciens fichiers quotidiens
+        for old_file in glob.glob(os.path.join(self.predictions_dir, "daily_*.csv")):
+            try:
+                os.remove(old_file)
+                logger.info(f"🧹 Ancien fichier supprimé: {old_file}")
+            except OSError as e:
+                logger.warning(f"Impossible de supprimer {old_file}: {e}")
         
         all_long_format_predictions = []
         

--- a/src/site_generator/generator.py
+++ b/src/site_generator/generator.py
@@ -48,7 +48,7 @@ def generate_site():
 
     # Prédictions du jour
     elo_preds_path = f'data/predictions/daily_elo_predictions_{today_str}.csv'
-    odds_preds_path = f'data/predictions/daily_{today_str}.csv'
+    odds_preds_path = 'data/predictions/daily_predictions.csv'
     elo_predictions_data = load_csv_to_dict(elo_preds_path, "Prédictions Elo du jour")
     odds_predictions_data = load_csv_to_dict(odds_preds_path, "Prédictions Cotes du jour")
 


### PR DESCRIPTION
## Summary
- write daily predictions to `daily_predictions.csv`
- clean existing `daily_*.csv` before saving new predictions
- update analyzer, site generator and docs for new filename

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68aefb8b17088333bcb5d238c51a95ba