### PR TITLE
Filter bets lacking bookmaker coverage

### DIFF
--- a/src/prediction/daily_predictions_workflow.py
+++ b/src/prediction/daily_predictions_workflow.py
@@ -233,12 +233,28 @@ class DailyPredictionsWorkflow:
         df = pd.DataFrame(processed_odds)
         df['odd'] = pd.to_numeric(df['odd'], errors='coerce')
         df.dropna(subset=['odd'], inplace=True)
-        
+
         df['bet_identifier'] = df['bet_type_name'].astype(str) + '_' + df['bet_value'].astype(str)
-        
-        # Calculer cotes moyennes
-        mean_odds = df.groupby('bet_identifier')['odd'].mean()
-        
+        # Compter le nombre de bookmakers distincts par pari
+        bookmaker_counts = (
+            df.groupby('bet_identifier')['bookmaker_id']
+            .nunique()
+            .reset_index(name='bookmaker_count')
+        )
+
+        # Conserver uniquement les paris suffisamment représentés
+        valid_bets = bookmaker_counts[
+            bookmaker_counts['bookmaker_count'] >= self.MIN_BOOKMAKERS_THRESHOLD
+        ]['bet_identifier']
+
+        if valid_bets.empty:
+            return {}
+
+        filtered_df = df[df['bet_identifier'].isin(valid_bets)]
+
+        # Calculer cotes moyennes sur le sous-ensemble fiable
+        mean_odds = filtered_df.groupby('bet_identifier')['odd'].mean()
+
         return mean_odds.to_dict()
 
     def calculate_similarity_for_all_bets(self, target_odds: Dict) -> Dict:

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -20,6 +20,24 @@ def predictions_workflow(mocker):
     workflow = DailyPredictionsWorkflow(rapidapi_key='dummy_key_for_testing')
     return workflow
 
+def test_process_fixture_odds_filters_bookmakers(predictions_workflow):
+    """Vérifie que les paris avec trop peu de bookmakers sont exclus."""
+    odds_data = [{
+        'bookmakers': [
+            {'id': 1, 'bets': [{'name': 'Match Winner', 'values': [{'value': 'Home', 'odd': '1.5'}]}]},
+            {'id': 2, 'bets': [{'name': 'Match Winner', 'values': [{'value': 'Home', 'odd': '1.6'}]}]},
+            {'id': 3, 'bets': [{'name': 'Match Winner', 'values': [{'value': 'Home', 'odd': '1.7'}]}]},
+            {'id': 4, 'bets': [{'name': 'Over/Under', 'values': [{'value': 'Over 2.5', 'odd': '2.0'}]}]},
+            {'id': 5, 'bets': [{'name': 'Over/Under', 'values': [{'value': 'Over 2.5', 'odd': '2.1'}]}]},
+        ]
+    }]
+
+    result = predictions_workflow.process_fixture_odds(1, odds_data)
+
+    assert 'Match Winner_Home' in result
+    assert result['Match Winner_Home'] == pytest.approx((1.5 + 1.6 + 1.7) / 3)
+    assert 'Over/Under_Over 2.5' not in result
+
 def test_calculate_similarity_with_all_thresholds(predictions_workflow):
     """
     Teste que les deux seuils (`MIN_SIMILAR_MATCHES_THRESHOLD` et


### PR DESCRIPTION
## Summary
- filter processed odds to only keep markets offered by at least MIN_BOOKMAKERS_THRESHOLD bookmakers
- compute average odds on remaining markets
- test fixture odds processing excludes markets with insufficient bookmakers

## Testing
- `pytest tests/test_predictions.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68aefb93e7f48333b00dda138de73edc