### PR TITLE
Track football players update log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__/
 
 # Log files
 *.log
+# Track the players update log
+!logs/football_players_update.log
 
 # Data artifacts
 *.parquet


### PR DESCRIPTION
## Summary
- allow tracking of `logs/football_players_update.log` while keeping generic log ignore rule
- preserve `logs/` directory via `.gitkeep`

## Testing
- `pre-commit run --files .gitignore` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pytest`
- `git add logs/football_players_update.log`

------
https://chatgpt.com/codex/tasks/task_b_68af0281c7f88333b407012066912b49